### PR TITLE
Log clear reliability

### DIFF
--- a/IronstoneCoreTests/IronstoneAutocadTestFixture.cs
+++ b/IronstoneCoreTests/IronstoneAutocadTestFixture.cs
@@ -18,10 +18,7 @@ namespace Jpp.Ironstone.Core.Tests
 
         public override void Setup()
         {
-            if (File.Exists(LogHelper.GetLogName()))
-            {
-                File.Delete(LogHelper.GetLogName());
-            }
+            LogHelper.ClearLog();
         }
     }
 }

--- a/IronstoneCoreTests/IronstoneCivilTestFixture.cs
+++ b/IronstoneCoreTests/IronstoneCivilTestFixture.cs
@@ -18,10 +18,7 @@ namespace Jpp.Ironstone.Core.Tests
 
         public override void Setup()
         {
-            if (File.Exists(LogHelper.GetLogName()))
-            {
-                File.Delete(LogHelper.GetLogName());
-            }
+            LogHelper.ClearLog();
         }
     }
 }

--- a/IronstoneCoreTests/IronstoneTestFixture.cs
+++ b/IronstoneCoreTests/IronstoneTestFixture.cs
@@ -23,10 +23,7 @@ namespace Jpp.Ironstone.Core.Tests
             config.TestSettings();
             ConfigurationHelper.CreateConfiguration(config);
 
-            if (File.Exists(LogHelper.GetLogName()))
-            {
-                File.Delete(LogHelper.GetLogName());
-            }
+            LogHelper.ClearLog();
         }
     }
 }

--- a/IronstoneCoreTests/LogHelper.cs
+++ b/IronstoneCoreTests/LogHelper.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 
 namespace Jpp.Ironstone.Core.Tests
 {
     class LogHelper
     {
+        private const int millisecondDelay = 100;
+        private const int retries = 5;
+        
         public static string GetLogName()
         {
             DateTime time = DateTime.Now;
@@ -15,6 +19,49 @@ namespace Jpp.Ironstone.Core.Tests
         {
             var readStream = File.Open(LogHelper.GetLogName(), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             return new StreamReader(readStream);
+        }
+        
+        public static bool IsFileLocked()
+        {
+            try
+            {
+                using(FileStream stream = File.Open(LogHelper.GetLogName(), FileMode.Open, FileAccess.Read, FileShare.None))
+                {
+                    stream.Close();
+                }
+            }
+            catch (IOException)
+            {
+                //the file is unavailable because it is:
+                //still being written to
+                //or being processed by another thread
+                //or does not exist (has already been processed)
+                return true;
+            }
+
+            //file is not locked
+            return false;
+        }
+
+        public static void ClearLog()
+        {
+            if (File.Exists(LogHelper.GetLogName()))
+            {
+                int loops = 0;
+                while (loops < retries)
+                {
+                    if (IsFileLocked())
+                    {
+                        Thread.Sleep(millisecondDelay);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                    loops++;
+                }
+                File.Delete(LogHelper.GetLogName());
+            }
         }
     }
 }


### PR DESCRIPTION
Added helper method to clear log files, with a delay to prevent file io errors when tests are run quickly back to back.

File.Delete was causing IO errors as previous instance was closing and writing to log